### PR TITLE
Fix for API changes in android-gradle plugin 3.3.0

### DIFF
--- a/android-gradle-aspectj/src/main/kotlin/com/archinamon/utils/VariantUtils.kt
+++ b/android-gradle-aspectj/src/main/kotlin/com/archinamon/utils/VariantUtils.kt
@@ -13,7 +13,7 @@ const val LANG_AJ = "aspectj"
 const val LANG_JAVA = "java"
 
 fun getJavaTask(baseVariantData: BaseVariantData): JavaCompile {
-    return baseVariantData.taskContainer.javacTask
+    return baseVariantData.taskContainer.javacTask.get()
 }
 
 fun getAjSourceAndExcludeFromJavac(project: Project, variantData: BaseVariantData): FileCollection {

--- a/android-gradle-aspectj/src/test/kotlin/com/archinamon/AndroidPluginTest.kt
+++ b/android-gradle-aspectj/src/test/kotlin/com/archinamon/AndroidPluginTest.kt
@@ -61,7 +61,7 @@ class AndroidPluginTest {
                     classpath 'org.aspectj:aspectjtools:$aspectjVersion'
 
                     // main dependencies
-                    classpath 'com.android.tools.build:gradle:3.2.0'
+                    classpath 'com.android.tools.build:gradle:3.3.0'
                     classpath files('${jarFile.absolutePath}')
                 }
             }
@@ -95,7 +95,7 @@ class AndroidPluginTest {
                     classpath 'org.aspectj:aspectjtools:$aspectjVersion'
 
                     // main dependencies
-                    classpath 'com.android.tools.build:gradle:3.2.0'
+                    classpath 'com.android.tools.build:gradle:3.3.0'
                     classpath files('${jarFile.absolutePath}')
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-androidGradleVersion=3.2.0
+androidGradleVersion=3.3.0
 aspectjVersion=1.9.1
 kotlinVersion=1.3.0
 org.gradle.jvmargs=-Xms256m -Xmx256m -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Changes

- Update android-gradle plugin to 3.3.0
- Fix the` getJavacTask` method from VariantUtils by using the new TaskProvider
- Update `AndroidPluginTest`'s `android-gradle` to 3.3.0

Fixes #91 