### PR TITLE
Make sure JAR files are copied as well when copying compiled .class files

### DIFF
--- a/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
+++ b/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
@@ -240,6 +240,16 @@ internal abstract class AspectJTransform(val project: Project, private val polic
             //copy compiled .class files to output directory
             FileUtil.copyDir(compiledAj, outputDir)
         }
+
+        transformInvocation.inputs.forEach { transformInput ->
+            // Ensure JARs are copied as well:
+            transformInput.jarInputs.forEach {
+                it.file.copyTo(
+                    transformInvocation.outputProvider.getContentLocation(it.name, inputTypes, scopes, Format.JAR),
+                    overwrite = true
+                )
+            }
+        }
     }
 
     private fun copyJar(outputProvider: TransformOutputProvider, jarInput: JarInput?): Boolean {


### PR DESCRIPTION
This fixes #108 It uses code provided by @jdvp as commented [here](https://github.com/Archinamon/android-gradle-aspectj/issues/108#issuecomment-628932437) 